### PR TITLE
Unlock sessions mutex in xds.Manager notify on context cancellation

### DIFF
--- a/pkg/xds/xds.go
+++ b/pkg/xds/xds.go
@@ -198,6 +198,7 @@ func (m *Manager) notify(ctx context.Context, resources []string) error {
 	// First try sending to sessions that aren't busy.
 	blocked := make(map[session]struct{})
 	m.sessionsMu.Lock()
+	defer m.sessionsMu.Unlock()
 	for session := range m.sessions {
 		select {
 		case session <- u:
@@ -219,7 +220,6 @@ func (m *Manager) notify(ctx context.Context, resources []string) error {
 			}
 		}
 	}
-	m.sessionsMu.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
We've seen a deadlock where xds configs stop getting updated. I think I've tracked it down to the case where the sessions mutex isn't released when the context is cancelled (`change notification timed out`).

It coincides with an `unable to decode an event from the watch stream: http2: client connection lost` error from the watchers. I haven't tried to figure out where the context is coming from, but its cancellation might have something to do with the connection error.